### PR TITLE
Add continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+cache: bundler
+sudo: false
+before_script: bundle exec jekyll build
+script: htmlproofer --assume-extension ./_site --check-html --check-opengraph --internal-domains="www.helicoptersofdc.com"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: ruby
 cache: bundler
 sudo: false
 before_script: bundle exec jekyll build
-script: htmlproofer --assume-extension ./_site --check-html --check-opengraph --internal-domains="www.helicoptersofdc.com"
+script: bundle exec htmlproofer --assume-extension ./_site --check-html --check-opengraph --internal-domains="www.helicoptersofdc.com"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: ruby
 cache: bundler
 sudo: false
 before_script: bundle exec jekyll build
-script: bundle exec htmlproofer --assume-extension ./_site --check-html --check-opengraph --internal-domains="www.helicoptersofdc.com"
+script: bundle exec htmlproofer --assume-extension ./_site --check-html --check-opengraph --internal-domains="www.helicoptersofdc.com" --disable-external

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'github-pages'
+gem 'html-proofer'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # dc-helicopters
-A guide to understanding the helicopters of Washington, DC.  
 
-Please [share feedback or let me know any mistakes you've found](https://github.com/gbinal/dc-helicopters/issues)!  
+[![Build Status](https://travis-ci.org/benbalter/dc-helicopters.svg?branch=master)](https://travis-ci.org/benbalter/dc-helicopters)
+
+A guide to understanding the helicopters of Washington, DC.
+
+Please [share feedback or let me know any mistakes you've found](https://github.com/gbinal/dc-helicopters/issues)!
 
 
 This website template was created by the talented folks at the CFPB.  I'm very grateful for their good work in government and in the open source community.

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,16 @@
 # Base configuration
 permalink: pretty
-exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
+exclude:
+  - LICENSE
+  - README.md
+  - vendor
+  - TERMS.md
+  - Gemfile
+  - Gemfile.lock
+  - CONTRIBUTING.md
+  - COPYING.txt
+  - CNAME
+
 markdown: kramdown
 
 #Prose.io editing info


### PR DESCRIPTION
To check for dead links and invalid HTML.

See https://github.com/gjtorikian/html-proofer for a full list of options.

For this to work, you'll want to enable Travis for the repo, which will fire on all pull requests, giving you confidence that a given PR won't "break the build".

Right now, it is properly failing with expected failures. See [example output](https://travis-ci.com/benbalter/dc-helicopters/builds/98671420).