### PR TITLE
Add links to ADS-B Exchange.

### DIFF
--- a/_helicopters/3-metropolitan-police-department-air-support-unit-falcon.md
+++ b/_helicopters/3-metropolitan-police-department-air-support-unit-falcon.md
@@ -17,6 +17,9 @@ The DC police department's helicopter, this is what you'll sometimes see with a 
 ### Trackable on Flightradar24 App?
 * No
 
+### Trackable on ADS-B Exchange?
+* Yes - [N911DC](https://globe.adsbexchange.com/?icao=ac9ab0), [N911AS](https://globe.adsbexchange.com/?icao=ac9a73)
+
 ### Details
 
 Able to operate at day or night, the main missions of this unit is searching for suspects or missing persons, assisting in vehicle pursuits (so that pursuing police cars can more safely maintain the chase), and observing large demonstrations.

--- a/_helicopters/4-us-coast-guard.md
+++ b/_helicopters/4-us-coast-guard.md
@@ -15,6 +15,9 @@ A set of armed Coast Guard helicopters play a role in the air defense of Washing
 ### Trackable on Flightradar24 App?
 * No.
 
+### Trackable on ADS-B Exchange?
+* Yes - [Website Link](https://globe.adsbexchange.com/?icao=ae26a8)
+
 ### Details
 
 Washington, DC has a multi-layered air defense system.  This includes (but I'm sure isn't limited to):

--- a/_helicopters/5-us-army-12th-aviation-battalion.md
+++ b/_helicopters/5-us-army-12th-aviation-battalion.md
@@ -14,6 +14,9 @@ Known as the Gold Tops (in contrast to the HMX-1 White Tops), the unit provides 
 ### Trackable on Flightradar24 App?
 * Unknown, but likely no.  
 
+### Trackable on ADS-B Exchange?
+* Some of them, sometimes - [One example](https://globe.adsbexchange.com/?icao=ae0eb6)
+
 ### Details
 
 Based out of Fort Belvoir, this unit play a number of other roles, but one of them is also VIP evacuation in the case of emergency.  While the HMX-1 squadron would ensure the evacuation of the President and his immediate advisors, it is this squadron that would spirit away other high ranking lawmakers and government leadership.

--- a/_helicopters/6-us-air-force-1st-helicopter-squadron.md
+++ b/_helicopters/6-us-air-force-1st-helicopter-squadron.md
@@ -11,7 +11,10 @@ An easily recognizable staple of the DC airspace, this unit provides the most re
 * [UH-1N Twin Hueys](https://en.wikipedia.org/wiki/Bell_UH-1N_Twin_Huey)
 
 ### Trackable on Flightradar24 App?
-* Unknown, but likely no.  
+* Unknown, but likely no.
+
+### Trackable on ADS-B Exchange?
+* Some of them, sometimes - [MUSEL14](https://globe.adsbexchange.com/?icao=ae6249), [MUSEL17](https://globe.adsbexchange.com/?icao=ae6250)
 
 ### Details
 

--- a/_helicopters/7-customs-border-patrol.md
+++ b/_helicopters/7-customs-border-patrol.md
@@ -12,6 +12,9 @@ image: /pictures/cbp.png
 ### Trackable on Flightradar24 App?
 * Yes - [Website Link](https://www.flightradar24.com/data/aircraft/N159CM)
 
+### Trackable on ADS-B Exchange?
+* Yes - [Website Link](https://globe.adsbexchange.com/?icao=a0ebdc)
+
 ### Details
 
 Numerous folks have helped me identify this helicopter as being a Sikorsky S-76 operated by the US Customs and Border Patrol. I'm still researching, but it seems that these help patrol the Washington area and provide security.  How ... I don't really know yet.  Are they armed?  What are they looking for?  Where are they based out of?  These questions are more I'm still working on and will provide more notes here when I find anything.  Let me know if you know any of these details.  

--- a/_helicopters/8-medstar.md
+++ b/_helicopters/8-medstar.md
@@ -12,9 +12,13 @@ Transporting medical patients around the DC area, the MedSTAR helicopters serve 
 
 ### FAA Registry Number 
 * [N138MH](https://registry.faa.gov/aircraftinquiry/NNum_Results.aspx?NNumbertxt=N138MH)
+* [N304ME](https://registry.faa.gov/aircraftinquiry/NNum_Results.aspx?NNumbertxt=N304ME)
 
 ### Trackable on Flightradar24 App?
-* Yes - [Website Link](https://www.flightradar24.com/data/aircraft/n138mh)
+* Yes - [N138MH](https://www.flightradar24.com/data/aircraft/n138mh), [N304ME](https://www.flightradar24.com/data/aircraft/n304me)
+
+### Trackable on ADS-B Exchange?
+* Yes - [N138MH](https://globe.adsbexchange.com/?icao=a09a04), [N304ME](https://globe.adsbexchange.com/?icao=a32f46)
 
 ### Details
 


### PR DESCRIPTION
I was able to identify a lot of the helicopters on ADS-B Exchange, including some that aren't trackable on Flightradar24.

To help corroborate the identifications I used resources like [this one](https://www.flyingnut.com/adsbmap/adsbMilitaryObs.php) and [this one](https://www.live-military-mode-s.eu/military%20mode-s%20database/).